### PR TITLE
Update AutoMunge.py to 1.75

### DIFF
--- a/AutoMunge_pkg/AutoMunge.py
+++ b/AutoMunge_pkg/AutoMunge.py
@@ -872,7 +872,7 @@ class AutoMunge:
 
 
     #apply onehotencoding
-    onehotencoder = OneHotEncoder(categories='auto')
+    onehotencoder = OneHotEncoder()
     cat_train_1hot = onehotencoder.fit_transform(cat_train_encoded.reshape(-1,1))
     cat_test_1hot = onehotencoder.fit_transform(cat_test_encoded.reshape(-1,1))
 
@@ -3433,7 +3433,7 @@ class AutoMunge:
                              'numbercategoryheuristic' : numbercategoryheuristic, \
                              'excludetransformscolumns' : excludetransformscolumns,\
                              'labelsencoding_dict' : labelsencoding_dict, \
-                             'automungeversion' : '1.74' })
+                             'automungeversion' : '1.75' })
 
 
 
@@ -3946,7 +3946,7 @@ class AutoMunge:
 
 
     #apply onehotencoding
-    onehotencoder = OneHotEncoder(categories='auto')
+    onehotencoder = OneHotEncoder()
     cat_test_1hot = onehotencoder.fit_transform(cat_test_encoded.reshape(-1,1))
 
     #append column header name to each category listing


### PR DESCRIPTION
Turned out a command we were using for the OneHotEncoder wasn't backwards compatible with sklearn 0.19.1 so going to revert to method that might result in an annoying warning caption for users of current version of sklearn, decided to prioritize backwards compatibility.