### PR TITLE
v1.80

### DIFF
--- a/AutoMunge_pkg/AutoMunge.py
+++ b/AutoMunge_pkg/AutoMunge.py
@@ -5018,7 +5018,7 @@ class AutoMunge:
                              'transform_dict' : transform_dict, \
                              'processdict' : processdict, \
                              'process_dict' : process_dict, \
-                             'automungeversion' : '1.8' })
+                             'automungeversion' : '1.80' })
 
     
     


### PR DESCRIPTION
PiPY was down when rolled out 1.8,I believe requires update to version number to resubmit