### PR TITLE
2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ and arguments.
 downstream machine learning model in the framework of a user's choice
 
 * trainID: the set of ID values corresponding to the train set if a ID
-column was passed to the function. This set may be useful if the shuffle
+column(s) was passed to the function. This set may be useful if the shuffle
 option was applied.
 
 * labels: a set of numerically encoded labels corresponding to the
@@ -427,12 +427,16 @@ training set does not include a label column.
 * trainID_column: a string of the column title for the column from the
 df_train set intended for use as a row identifier value (such as could
 be sequential numbers for instance). The function defaults to False for
-cases where the training set does not include an ID column.
+cases where the training set does not include an ID column. A user can 
+also pass a list of string columns titles such as to carve out multiple
+columns to be excluded from processing but consistently partitioned.
 
 * testID_column: a string of the column title for the column from the
 df_test set intended for use as a row identifier value (such as could be
 sequential numbers for instance). The function defaults to False for
-cases where the training set does not include an ID column.
+cases where the training set does not include an ID column. A user can 
+also pass a list of string columns titles such as to carve out multiple
+columns to be excluded from processing but consistently partitioned.
 
 * valpercent1: a float value between 0 and 1 which designates the percent
 of the training data which will be set aside for the first validation
@@ -860,7 +864,9 @@ include an ID column.
 * testID_column: a string of the column title for the column from the
 df_test set intended for use as a row identifier value (such as could be
 sequential numbers for instance). The function defaults to False for
-cases where the training set does not include an ID column.
+cases where the training set does not include an ID column. A user can 
+also pass a list of string columns titles such as to carve out multiple
+columns to be excluded from processing but consistently partitioned.
 
 * labelscolumn: default to False indicates that a labels column is not 
 included in the test set passed to postmunge. A user can either pass


### PR DESCRIPTION
a few clarifications associated with the new functionality for passing lists of ID column strings such as to trainID_column from version 2.13