### PR TITLE
Update Automunger.py

### DIFF
--- a/Automunge/Automunger.py
+++ b/Automunge/Automunger.py
@@ -713,6 +713,60 @@ class AutoMunge:
                                      'niecesnephews' : [], \
                                      'coworkers' : [], \
                                      'friends' : []}})
+
+    transform_dict.update({'or15' : {'parents' : ['or15'], \
+                                     'siblings': [], \
+                                     'auntsuncles' : [], \
+                                     'cousins' : [NArw], \
+                                     'children' : ['sp13'], \
+                                     'niecesnephews' : [], \
+                                     'coworkers' : ['1010'], \
+                                     'friends' : []}})
+  
+    transform_dict.update({'or16' : {'parents' : ['or16'], \
+                                     'siblings': [], \
+                                     'auntsuncles' : [], \
+                                     'cousins' : [NArw], \
+                                     'children' : ['nmr2'], \
+                                     'niecesnephews' : ['sp13'], \
+                                     'coworkers' : ['1010'], \
+                                     'friends' : []}})
+    
+    transform_dict.update({'or17' : {'parents' : ['or17'], \
+                                     'siblings': [], \
+                                     'auntsuncles' : [], \
+                                     'cousins' : [NArw], \
+                                     'children' : ['sp14'], \
+                                     'niecesnephews' : [], \
+                                     'coworkers' : ['1010'], \
+                                     'friends' : []}})
+    
+    transform_dict.update({'or18' : {'parents' : ['or18'], \
+                                     'siblings': [], \
+                                     'auntsuncles' : [], \
+                                     'cousins' : [NArw], \
+                                     'children' : ['nmr2'], \
+                                     'niecesnephews' : ['sp14'], \
+                                     'coworkers' : ['1010'], \
+                                     'friends' : []}})
+    
+    transform_dict.update({'sp13' : {'parents' : ['sp13'], \
+                                     'siblings': [], \
+                                     'auntsuncles' : [], \
+                                     'cousins' : [NArw], \
+                                     'children' : [], \
+                                     'niecesnephews' : ['sp10'], \
+                                     'coworkers' : ['ord3'], \
+                                     'friends' : []}})
+    
+    transform_dict.update({'sp14' : {'parents' : ['sp14'], \
+                                     'siblings': [], \
+                                     'auntsuncles' : [], \
+                                     'cousins' : [NArw], \
+                                     'children' : [], \
+                                     'niecesnephews' : ['sp13'], \
+                                     'coworkers' : ['ord3'], \
+                                     'friends' : []}})
     
     transform_dict.update({'sp11' : {'parents' : ['sp11'], \
                                      'siblings': [], \
@@ -2092,6 +2146,42 @@ class AutoMunge:
     process_dict.update({'sp12' : {'dualprocess' : self.process_spl2_class, \
                                    'singleprocess' : None, \
                                    'postprocess' : self.postprocess_spl2_class, \
+                                   'NArowtype' : 'justNaN', \
+                                   'MLinfilltype' : 'exclude', \
+                                   'labelctgy' : 'ord3'}})
+    process_dict.update({'or15' : {'dualprocess' : None, \
+                                   'singleprocess' : self.process_UPCS_class, \
+                                   'postprocess' : None, \
+                                   'NArowtype' : 'justNaN', \
+                                   'MLinfilltype' : 'exclude', \
+                                   'labelctgy' : 'ord3'}})
+    process_dict.update({'or16' : {'dualprocess' : None, \
+                                   'singleprocess' : self.process_UPCS_class, \
+                                   'postprocess' : None, \
+                                   'NArowtype' : 'justNaN', \
+                                   'MLinfilltype' : 'exclude', \
+                                   'labelctgy' : 'ord3'}})
+    process_dict.update({'or17' : {'dualprocess' : None, \
+                                   'singleprocess' : self.process_UPCS_class, \
+                                   'postprocess' : None, \
+                                   'NArowtype' : 'justNaN', \
+                                   'MLinfilltype' : 'exclude', \
+                                   'labelctgy' : 'ord3'}})
+    process_dict.update({'or18' : {'dualprocess' : None, \
+                                   'singleprocess' : self.process_UPCS_class, \
+                                   'postprocess' : None, \
+                                   'NArowtype' : 'justNaN', \
+                                   'MLinfilltype' : 'exclude', \
+                                   'labelctgy' : 'ord3'}})
+    process_dict.update({'sp13' : {'dualprocess' : self.process_spl9_class, \
+                                   'singleprocess' : None, \
+                                   'postprocess' : self.postprocess_spl9_class, \
+                                   'NArowtype' : 'justNaN', \
+                                   'MLinfilltype' : 'exclude', \
+                                   'labelctgy' : 'ord3'}})
+    process_dict.update({'sp14' : {'dualprocess' : self.process_spl9_class, \
+                                   'singleprocess' : None, \
+                                   'postprocess' : self.postprocess_spl9_class, \
                                    'NArowtype' : 'justNaN', \
                                    'MLinfilltype' : 'exclude', \
                                    'labelctgy' : 'ord3'}})
@@ -15377,7 +15467,7 @@ class AutoMunge:
                              'nmrc':[], 'nmr2':[], 'nmr3':[], 'nmcm':[], 'nmc2':[], 'nmc3':[], \
                              'nmr7':[], 'nmr8':[], 'nmr9':[], 'nmc7':[], 'nmc8':[], 'nmc9':[], \
                              'ors2':[], 'ors5':[], 'ors6':[], 'ors7':[], \
-                             'or11':[], 'or12':[], 'or13':[], 'or14':[], \
+                             'or11':[], 'or12':[], 'or15':[], 'or16':[], 'or17':[], 'or18':[], \
                              'date':[], 'dat2':[], 'dat6':[], 'wkdy':[], 'bshr':[], 'hldy':[], \
                              'yea2':[], 'mnt2':[], 'mnt6':[], 'day2':[], 'day5':[], \
                              'hrs2':[], 'hrs4':[], 'min2':[], 'min4':[], 'scn2':[], \
@@ -16755,7 +16845,7 @@ class AutoMunge:
         
         
     #we'll create some tags specific to the application to support postprocess_dict versioning
-    automungeversion = '2.86'
+    automungeversion = '2.87'
     application_number = random.randint(100000000000,999999999999)
     application_timestamp = dt.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f")
     version_combined = '_' + str(automungeversion) + '_' + str(application_number) + '_' \


### PR DESCRIPTION
- new processing root category family trees: or15 / or16 / or17 / or18
- comparable to or11 / or12 / or13 / or14
- but incorporate an UPCS transform upstream of encodings
- for consistent encodings in case of string case discrepencies
- and make use of spl9 / sp10 instead of spl2 / spl5
- for assumption that set of unique values in test set is same or subset of train set 
- (for more efficient postmunge)