### PR TITLE
v2.87

### DIFF
--- a/Automunge/Automunger.py
+++ b/Automunge/Automunger.py
@@ -66,10 +66,6 @@ class AutoMunge:
     #assembles the range of transformations to be applied based on the evaluated \
     #category of data
     #the primitives are intented as follows:
-    #_greatgrandparents_: supplemental column derived from source column, only applied
-    #to first generation, with downstream transforms included
-    #_grandparents_: supplemental column derived from source column, only applied
-    #to first generation
     #_parents_: replace source column, with downstream trasnforms performed
     #_siblings_: supplemental column derived from source column, \
     #with downstream transforms performed


### PR DESCRIPTION
- new processing root category family trees: or15 / or16 / or17 / or18
- comparable to or11 / or12 / or13 / or14
- but incorporate an UPCS transform upstream of encodings
- for consistent encodings in case of string case discrepencies
- and make use of spl9 / sp10 instead of spl2 / spl5
- for assumption that set of unique values in test set is same or subset of train set 
- (for more efficient postmunge)