### PR TITLE
v2.90

### DIFF
--- a/Automunge/Automunger.py
+++ b/Automunge/Automunger.py
@@ -22339,6 +22339,10 @@ class AutoMunge:
           #this needs to have same number of columns as text category
           np_testinfill = np.zeros(shape=(1,len(columnslist)))
           
+        #convert infill values to dataframe
+  #       df_traininfill = pd.DataFrame(np_traininfill, columns = columnslist)
+        df_testinfill = pd.DataFrame(np_testinfill, columns = columnslist) 
+          
       if MLinfilltype in ['1010']:
 
   #       #train logistic regression model using scikit-learn for binary classifier


### PR DESCRIPTION
2.89 updates
- ML infill now available for '1010' binary encoded categorical sets
- Feature importance evaluation now available for '1010' binary encoded categorical label sets
- new MLinfilltype '1010' available for assignment in processdict
- thinking about making '1010' the new default for categorical sets instead of one-hot encoding, first will put some thought into specifics, to be continued...

2.90 updates
- quick bug fix