### PR TITLE
v3.87

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ train, trainID, labels, \
 validation1, validationID1, validationlabels1, \
 validation2, validationID2, validationlabels2, \
 test, testID, testlabels, \
-testlabelsencoding_dict, finalcolumns_train, finalcolumns_test, \
+labelsencoding_dict, finalcolumns_train, finalcolumns_test, \
 featureimportance, postprocess_dict \
 = am.automunge(df_train)
 ```


### PR DESCRIPTION
corrected naming of returned sets (testlabelsencoding_dict -> labelsencoding_dict) in one of the demonstrations