### PR TITLE
6.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,16 +101,16 @@ Where e.g. for train set processing  with default parameters run:
 train, train_ID, labels, \
 val, val_ID, val_labels, \
 test, test_ID, test_labels, \
-postprocess_dict \
-= am.automunge(df_train)
+postprocess_dict = \
+am.automunge(df_train)
 ```
 Or for subsequent consistent processing of train or test data, using the
 dictionary returned from original application of automunge(.), run:
 
 ```
 test, test_ID, test_labels, \
-postreports_dict \
-= am.postmunge(postprocess_dict, df_test)
+postreports_dict = \
+am.postmunge(postprocess_dict, df_test)
 ```
 Importantly, if the df_train set passed to automunge(.) includes a column
 intended for use as labels, it should be designated with the labels_column
@@ -333,8 +333,8 @@ am = AutoMunge()
 train, train_ID, labels, \
 val, val_ID, val_labels, \
 test, test_ID, test_labels, \
-postprocess_dict \
-= am.automunge(df_train)
+postprocess_dict = \
+am.automunge(df_train)
 ```
 
 The full set of parameters available to be passed are given here, with
@@ -1539,8 +1539,8 @@ additional data set.
 
 ```
 test, test_ID, test_labels, \
-postreports_dict \
-= am.postmunge(postprocess_dict, df_test)
+postreports_dict = \
+am.postmunge(postprocess_dict, df_test)
 ```          
 
 ## postmunge(.) returned sets:


### PR DESCRIPTION
small cleanups to make uniform convention for '=' placement in function calls