### PR TITLE
6.54

### DIFF
--- a/README.md
+++ b/README.md
@@ -2135,10 +2135,11 @@ When root categories of transformations are not assigned for a given column in
 assigncat, automunge performs an evaluation of data properties to infer 
 appropriate means of feature engineering and numerical encoding. The default
 categories of transformations are as follows:
-- nmbr: for numerical data, columns are treated with z-score normalization. If 
+- nmbr: for numeric data, columns are treated with z-score normalization. If 
 binstransform parameter was activated this will be supplemented by a collection
 of bins indicating number of standard deviations from the mean. Note that deafult infill
-performed prior to ML infill is imputation with negative zero.
+performed prior to ML infill is imputation with negative zero. The exception is for
+numeric data received in a column with pandas 'categoric' data type.
 - 1010: for categorical data excluding special cases described following, columns are 
 subject to binarization encoding via '1010'. If the 
 number of unique entries in the column exceeds the parameter 'numbercategoryheuristic'
@@ -2620,7 +2621,18 @@ qttf converts to a normal output distribution, qtt2 converts to a uniform output
   - driftreport postmunge metrics: mean
   - returned datatype: based on automunge(.) floatprecision parameter (defaults to float32)
   - inversion available: yes with partial recovery
-
+* trigometric functions sint/cost/tant/arsn/arcs/artn: performs trigometric trasnformations.
+Transforms are built on top of numpy np.sin/np.cos/np.tan/np.arcsin/np.arccos/np.arctan respectively.
+  - useful for: common mathematic transform
+  - default infill: adjinfill
+  - default NArowtype: numeric
+  - suffix appender: based on the family tree category
+  - assignparam parameters accepted:
+    - 'operation': defaults to operation associated with the function, accepts {'sin', 'cos', 'tan', 'arsn', 'arcs', 'artn'}
+  - driftreport postmunge metrics: maximum, minimum
+  - returned datatype: based on automunge(.) floatprecision parameter (defaults to float32)
+  - inversion available: yes with partial recovery
+  
 Q Notation family of transforms return a multicolumn binary encoded set with registers for sign, integers, and fractionals.
 Transforms accept parameters integer_bits / fractional_bits / sign_bit for register sizes, care should be taken for 
 adequate registers to avoid overflow (overflow entries have values replaced with max or min capacity based on register sizes). 
@@ -3967,6 +3979,9 @@ avoid unintentional duplication.
 - 'absl',
 - 'addd',
 - 'aggt',
+- 'arcs',
+- 'arsn',
+- 'artn',
 - 'bins',
 - 'bkb3',
 - 'bkb4',
@@ -4004,6 +4019,7 @@ avoid unintentional duplication.
 - 'bxc5',
 - 'bxcx',
 - 'copy',
+- 'cost',
 - 'd2d2',
 - 'd2dt',
 - 'd3d2',
@@ -4242,6 +4258,7 @@ avoid unintentional duplication.
 - 'shf8',
 - 'shfl',
 - 'shft',
+- 'sint',
 - 'smth',
 - 'sp10',
 - 'sp11',
@@ -4268,6 +4285,7 @@ avoid unintentional duplication.
 - 'srch',
 - 'strn',
 - 'strg',
+- 'tant',
 - 'texd',
 - 'text',
 - 'tlbn',


### PR DESCRIPTION
added trigonometric functions to library
clarification to default transforms that received numeric data of pandas categoric type is applied to categoric transforms (bnry or 1010)